### PR TITLE
chore: adopt the shared ruff standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,15 @@ repos:
         language: system
         types: [python]
       # Run the linter (inherits config from pyproject.toml)
+      # The tests are linted through per-file-ignores, not excluded — see the
+      # "tests/**" table in pyproject.toml. An exclude here would put them back
+      # out of scope at commit time and make that table dead config locally.
       - id: ruff-check
         name: ruff linter
         entry: uv run ruff check
         language: system
         types: [python]
         args: [--fix]
-        exclude: ^tests/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/app/requirements_inspector_controller.py
+++ b/app/requirements_inspector_controller.py
@@ -10,13 +10,16 @@ from typing import TYPE_CHECKING, TypedDict
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Response
-from python_requirements_inspector.workitem_analyzer import WorkitemAnalyzer  # type: ignore
+from python_requirements_inspector.workitem_analyzer import WorkitemAnalyzer  # type: ignore[import-untyped]
 
 from app.constants import POLARION_REQUIREMENTS_INSPECTOR_SERVICE_VERSION_HEADER, POLARION_REQUIREMENTS_INSPECTOR_VERSION_HEADER, PYTHON_VERSION_HEADER
 from app.type_definitions import VersionSchema, WorkItemSchema
 
 if TYPE_CHECKING:
-    from python_requirements_inspector.type_definitions import RequirementsInspectorResponseItem  # type: ignore
+    from python_requirements_inspector.type_definitions import RequirementsInspectorResponseItem  # type: ignore[import-untyped]
+
+
+logger = logging.getLogger(__name__)
 
 
 class Config(TypedDict):
@@ -40,11 +43,10 @@ async def check_request_size(request: Request, call_next: Callable[[Request], Aw
     if size > config["request_size_limit"]:
         return Response("JSON Body too large", status_code=413, media_type="plain/text")
 
-    response = await call_next(request)
-    return response
+    return await call_next(request)
 
 
-@app.get("/version", response_model=VersionSchema)
+@app.get("/version")
 async def version() -> VersionSchema:
     """
     Returns:
@@ -87,7 +89,8 @@ async def inspect_workitems(work_items: list[WorkItemSchema]) -> Response:
             media_type="application/json",
             status_code=200,
         )
-    except Exception as e:  # pylint: disable=broad-except
+    # This is the HTTP boundary: it must answer 500 rather than leak the exception.
+    except Exception as e:  # noqa: BLE001
         return process_error(e, "Unknown exception handled during processing", 500)
 
 
@@ -119,5 +122,5 @@ def process_error(e: Exception, err_msg: str, status: int) -> Response:
     Returns:
         flask.Response: Flask Response object sent back to the client
     """
-    logging.exception(e)
-    raise HTTPException(status_code=status, detail=err_msg)
+    logger.error("%s: %s", err_msg, e, exc_info=e)
+    raise HTTPException(status_code=status, detail=err_msg) from e

--- a/app/requirements_inspector_service.py
+++ b/app/requirements_inspector_service.py
@@ -9,10 +9,12 @@ import sys
 from app.constants import POLARION_REQUIREMENTS_INSPECTOR_SERVICE_VERSION_HEADER
 from app.requirements_inspector_controller import start_server
 
+logger = logging.getLogger(__name__)
+
 
 def main(port: int, request_size_limit: int, log_level: str) -> None:
     logging.getLogger().setLevel(logging.INFO)
-    logging.info("Requirements Inspector Service running on port: %d", port)
+    logger.info("Requirements Inspector Service running on port: %d", port)
     logging.getLogger().setLevel(log_level.upper())
 
     polarion_requirements_inspector_version = importlib.metadata.version("python-requirements-inspector")

--- a/app/requirements_inspector_service.py
+++ b/app/requirements_inspector_service.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 def main(port: int, request_size_limit: int, log_level: str) -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    # Install a handler before logging anything. The module-level logging.info
+    # used to do this implicitly; a named logger has no such fallback and would
+    # drop the line at lastResort, whose level is WARNING.
+    logging.basicConfig(level=logging.INFO)
     logger.info("Requirements Inspector Service running on port: %d", port)
     logging.getLogger().setLevel(log_level.upper())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,34 +44,66 @@ packages = ["app"]
 line-length = 240
 fix = true
 show-fixes = true
-exclude = [
-    "tests/*"  # Exclude all test files from linting
-]
 
 [tool.ruff.lint]
-extend-select = [
-    # --- Recommended ---
-    "E", "W", # pycodestyle errors and warnings
-    "F",      # Pyflakes
-    "I",      # isort
-    "C4",     # flake8-comprehensions
-    "C90",    # mccabe
-    "B",      # flake8-bugbear
-    "UP",     # pyupgrade
-    "S",      # flake8-bandit
-    "PL",     # Pylint
-    "PTH",    # flake8-pathlib
-    "TCH",    # type-checking imports
-    "SIM",    # flake8-simplify
-    "T20",    # flake8-print
-    "ERA",    # eradicate
+# Shared standard for all SBB Python repositories.
+# Never use extend-select: it inherits ruff's implicit default, which widened in
+# ruff 0.16 and broke CI everywhere. Keep preview off, preview rules churn.
+select = ["ALL"]
+preview = false
+ignore = [
+    # ruff format owns this formatting decision
+    "COM812",  # trailing comma
+    "Q000",    # inline string quotes
+    "Q001",    # multiline string quotes
+    "Q002",    # docstring quotes
+    "Q003",    # escaped quotes
+
+    # Not our convention
+    "D",       # docstrings are optional, we mandate no docstring style
+    "CPY001",  # we ship no copyright headers
+    "FIX002",  # a TODO is a normal marker, not a defect
+    "EM101",   # a literal at the raise site reads better than a temp name
+    "EM102",   # same for an f-string
+    "TRY003",  # we want the full message where the raise happens
+    "TRY400",  # a handled error is logged without a traceback
+    "TRY401",  # the exception text belongs on the log line, not only in the traceback
+    "G004",    # we ingest plain log lines, not templates, so f-strings are fine
+    "ANN401",  # Any is correct at JSON and **kwargs boundaries
+    "FBT001",  # a boolean query parameter is part of the HTTP API
+    "FBT002",  # same, with a default
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.pylint]
+max-args = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
-    "S101", # No assert rule (bandit)
-    "PLR2004", # No magic values (pylint)
+    "S101",    # assert is how a test states its expectation
+    "S105",    # test credentials are fake by construction
+    "S106",    # same, passed as an argument
+    "S108",    # a temp path in a test is not a shared temp path
+    "S603",    # tests run known helper binaries
+    "S607",    # those binaries come from PATH on purpose
+    "SLF001",  # a test may assert on internal state
+    "PLC0415", # a local import is how a test patches a module
+    "ANN",     # a test signature carries no type information
+    "ARG",     # a fixture argument is used by pytest, not by the body
+    "PLR2004", # a literal is readable test data
+    "PT",      # unittest style is allowed next to pytest style
+    "E402",    # a test may import after patching
+    "TC",      # a test module is imported once, deferring imports buys nothing
+    "S104",    # a host string in test data is not a binding
+    "FBT003",  # mock.patch takes the replacement value positionally
+    "C901",    # a fixture is linear setup, splitting it hides the order
+    "PLR0912", # same, for its branches
+    "PLR0915", # same, for its statements
 ]
+
+# Repository-specific ignores belong below this line, each with a reason.
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,16 @@ show-fixes = true
 select = ["ALL"]
 preview = false
 ignore = [
-    # ruff format owns this formatting decision
+    # ruff format owns this formatting decision. COM812 is the only rule ruff
+    # itself reports as conflicting, so it is the only entry here. The Q00x rules
+    # are deliberately absent rather than ignored: Q000, Q002 and Q003 fire
+    # nowhere across the eight repositories, and Q001 fires in one of them but is
+    # auto-fixable and ruff format runs before ruff check in both tox.ini and
+    # pre-commit, so the formatter resolves it. That ordering is load-bearing:
+    # reverse it — the upstream ruff-pre-commit example puts check first — and
+    # these entries have to come back. The quote decision itself is pinned at the
+    # bottom of this file, on both the format and the lint side.
     "COM812",  # trailing comma
-    "Q000",    # inline string quotes
-    "Q001",    # multiline string quotes
-    "Q002",    # docstring quotes
-    "Q003",    # escaped quotes
 
     # Not our convention
     "D",       # docstrings are optional, we mandate no docstring style
@@ -118,8 +122,22 @@ max-args = 10
 # glob named "ignore" that matches no file: it is accepted, it silences
 # nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
+[tool.ruff.lint.flake8-quotes]
+# The lint half of the quote decision. These are what Q000, Q001 and Q002 read,
+# and with the Q rules enabled they decide a lint result, so they are stated
+# rather than inherited. Keep them equal to format.quote-style below: diverge and
+# Q000 fires on the string the formatter just rewrote.
+inline-quotes = "double"
+multiline-quotes = "double"
+docstring-quotes = "double"
+# The fourth option, and the one that decides whether Q003 runs at all: set it to
+# false and the rule stops reporting with nothing red to show for it.
+avoid-escape = true
+
 [tool.ruff.format]
 line-ending = "lf"
+# The format half. Changing this means changing flake8-quotes above in step.
+quote-style = "double"
 
 [tool.mypy]
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ show-fixes = true
 # Shared standard for all SBB Python repositories.
 # Never use extend-select: it inherits ruff's implicit default, which widened in
 # ruff 0.16 and broke CI everywhere. Keep preview off, preview rules churn.
+#
+# ALL still means "every stable rule in the installed ruff", so a ruff bump can
+# introduce findings. That is the accepted trade: a clean bump automerges, and a
+# dirty one turns the new rules into a change someone reads. What this config
+# removes is the version dependency we did not choose and could not see.
 select = ["ALL"]
 preview = false
 ignore = [
@@ -62,7 +67,8 @@ ignore = [
     # Not our convention
     "D",       # docstrings are optional, we mandate no docstring style
     "CPY001",  # we ship no copyright headers
-    "FIX002",  # a TODO is a normal marker, not a defect
+    "FIX002",  # a TODO is a normal marker, not a defect; TD002 and TD003 still
+               # require it to name an author and link an issue
     "EM101",   # a literal at the raise site reads better than a temp name
     "EM102",   # same for an f-string
     "TRY003",  # we want the full message where the raise happens
@@ -97,6 +103,7 @@ max-args = 10
     "E402",    # a test may import after patching
     "TC",      # a test module is imported once, deferring imports buys nothing
     "S104",    # a host string in test data is not a binding
+    "S314",    # a test parses the XML fixture it wrote itself
     "FBT003",  # mock.patch takes the replacement value positionally
     "C901",    # a fixture is linear setup, splitting it hides the order
     "PLR0912", # same, for its branches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,13 @@ max-args = 10
     "PLR0915", # same, for its statements
 ]
 
-# Repository-specific ignores belong below this line, each with a reason.
+# Repository-specific per-file ignores belong below this line, each with a
+# reason, and each in the "glob" = ["RULE"] form of the table above.
+#
+# A repository-wide ignore does NOT go here. This is still
+# [tool.ruff.lint.per-file-ignores], so a bare ignore = ["RULE"] parses as a
+# glob named "ignore" that matches no file: it is accepted, it silences
+# nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,17 +1,18 @@
 import importlib
 import importlib.metadata
 import json
+import re
+import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import NamedTuple
-import re
 
 import docker
 import pytest
 import requests
 from docker.models.containers import Container
 from python_requirements_inspector.type_definitions import RequirementsInspectorResponseItem, WorkItem
-import subprocess
 
 from app.constants import (
     POLARION_REQUIREMENTS_INSPECTOR_SERVICE_VERSION_HEADER,
@@ -63,7 +64,7 @@ def test_params(requirements_inspector_container: Container):
     session = requests.Session()
     python_version_pattern = re.compile(r"python (\d\.\d{1,2}.\d{1,2})")
     python_version = ""
-    with open(".tool-versions", "r", encoding="utf-8") as tool_versions:
+    with Path(".tool-versions").open(encoding="utf-8") as tool_versions:
         match = re.search(python_version_pattern, tool_versions.read())
         if not match:
             raise ValueError("Python version not found")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,10 +1,9 @@
 import logging
 import os
+from unittest.mock import patch
 
 from app.constants import POLARION_REQUIREMENTS_INSPECTOR_SERVICE_VERSION_HEADER
-from app.requirements_inspector_service import main
-from unittest.mock import patch
-from app.requirements_inspector_service import parse_args
+from app.requirements_inspector_service import main, parse_args
 
 
 def test_sys_exit():


### PR DESCRIPTION
Adopts the shared ruff standard defined in https://github.com/SchweizerischeBundesbahnen/open-source-polarion-python-repo-template/pull/130.

Replaces `extend-select` with `select = ["ALL"]`, so the enabled rules no
longer depend on the installed ruff version, and lints the tests through
`per-file-ignores` instead of excluding them.

Ten findings fixed: module loggers instead of the root logger, specific
type-ignore codes, `Path.open` in the container test, and a redundant FastAPI
`response_model`.

The blind `except` at the HTTP boundary now states why it is blind, and the
stale `# pylint: disable=broad-except` next to it is gone, since pylint is not
installed in any of these repositories.

Verified: ruff 0.15.22 and 0.16.2 both clean, mypy clean, 20 tests pass.