### PR TITLE
docs: record why uv sync uses --locked and tox uses --frozen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@
 ## Non-obvious gotchas
 
 - **Required env var**: The service won't start without `POLARION_REQUIREMENTS_INSPECTOR_SERVICE_VERSION` being set.
-- **`python-requirements-inspector` is not on PyPI** — it's installed as a WHL directly from GitHub Releases. This is why a Renovate custom regex manager exists in `renovate.json`.
+- **`python-requirements-inspector` is not on PyPI** — it's installed as a WHL directly from GitHub Releases, which is why a Renovate custom regex manager exists in `renovate.json`. A regex manager does string replacement only and has no lock-file step, so every Renovate bump of it lands with a stale `uv.lock` and CI fails on `uv sync --locked`; run `uv lock` on the branch. Retiring the URL dependency is tracked in `python-requirements-inspector#181`.
+- **`uv sync --locked` in CI and `--frozen` in `tox.ini` are both deliberate — neither is template drift.** This repo comes from `open-source-polarion-docker-repo-template`, not the Python one, and that template's `ci.yml` also uses `--locked` (synced in #130). `tox.ini` uses `--frozen` because for a direct URL dependency `uv run` re-fetches the wheel metadata from GitHub before every command, until GitHub answers `refused stream before processing any application logic` (#116 → #115). CI's `--locked` and the `uv lock --check` pre-commit hook are the two layers keeping `pyproject.toml` and `uv.lock` in agreement, and Renovate commits skip pre-commit. The `uv-venv-lock-runner` migration is open as #125.
 - **`numpy>=2.0` override in `pyproject.toml` is intentional** — numpy 1.x has no Python 3.13 wheels; spacy/thinc now support numpy 2.x.
 - **Pre-commit blocks direct commits to `main`** — use `--no-verify` only for emergency direct pushes; otherwise use a branch + PR.
 - **Always use `uv run tox`**, not bare `tox` — the project uses uv as the runner.


### PR DESCRIPTION
## Summary

Records two non-discoverable facts in `CLAUDE.md`, both established while investigating why #138 is red.

1. **`uv sync --locked` in `ci.yml` and `--frozen` in `tox.ini` are deliberate, not template drift.** During the investigation both were initially misread as drift, and relaxing them was proposed. The provenance is now written down: `--locked` arrived with the template sync in #130, and `--frozen` is the fix from #116 → #115, where `uv run` re-fetched the wheel metadata from GitHub before every command for the direct URL dependency until GitHub answered `refused stream before processing any application logic`. The entry also names the template this repository actually derives from, `open-source-polarion-docker-repo-template`, and points at #125 for the still-open `uv-venv-lock-runner` migration.

2. **A Renovate bump of `python-requirements-inspector` always lands with a stale `uv.lock`.** The dependency is tracked by a custom regex manager, which performs a plain string replacement and has no lock-file update step, so `pyproject.toml` is bumped while `uv.lock` keeps the previous version and hash, and CI then fails on `uv sync --locked`. #138 is the first Renovate-generated bump of this package, which is why the gap has not surfaced before. The workaround (`uv lock` on the branch) and the upstream issue that would retire the URL dependency altogether are both recorded.

Weakening `--locked` would not fix #138: `--frozen` would install the previous version and report success, so automerge could land a `pyproject.toml`/`uv.lock` mismatch on `main`.

## Issues addressed

- Refs #125 — the `uv-venv-lock-runner` migration is referenced, not performed.
- Refs #138 — documents the cause; the pull request itself is untouched and still red.
- Refs `SchweizerischeBundesbahnen/python-requirements-inspector#181` — publishing the package to an index, which would remove the root cause behind both recorded facts.

## Test plan

- [ ] CI green on this pull request.
- [ ] Reviewer confirms the recorded provenance matches #130, #116 and #115.
